### PR TITLE
fix(ant) Fix error message

### DIFF
--- a/analyzers/ant/ant.go
+++ b/analyzers/ant/ant.go
@@ -105,7 +105,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 
 	log.Debugf("resolving ant libs in: %s", libdir)
 	if ok, err := files.ExistsFolder(a.Module.Dir, libdir); !ok || err != nil {
-		return graph.Deps{}, errors.New("unable to resolve library directory, try specifying it using the `modules.options.libdir` property in `fossa.yml`")
+		return graph.Deps{}, errors.New("unable to resolve library directory, try specifying it using the `modules.options.libdir` property in `.fossa.yml`")
 	}
 
 	jarFilePaths, err := doublestar.Glob(filepath.Join(libdir, "*.jar"))


### PR DESCRIPTION
When erroring out due to unresolved library directories,
the message incorrectly points to `fossa.yml` instead of
the correct `.fossa.yml`.

Signed-off-by: Christian Witts <cwitts@gmail.com>